### PR TITLE
Fixed memory leak caused by not deallocating after Box::leak.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,15 @@ pub mod processor {
             }
         }
 
+	for (k, v) in abbreviations {
+	    unsafe{
+		let ptr_k = k as *const _;
+		let ptr_v = v as *const _;
+		core::ptr::drop_in_place(&ptr_k as *const _ as *mut Box<[&str; 3]>);
+		core::ptr::drop_in_place(&ptr_v as *const _ as *mut Box<[&str; 3]>);		    
+	    }
+	}
+	
         final_segmented_sentences
     }
 


### PR DESCRIPTION
Hi! I was using your library for very large amounts of text, and I noticed that the memory use of the library was very high, so I found the memory leak and fixed it using very brief (albeit, unsafe) code. I just tested the library by processing about 16GB worth of text in parallel and it works just fine.